### PR TITLE
feat: verify URL content,use baidu for proxy alive test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.exe
+*.exe~
 .history
 .vscode
 *.zip
 cmd/rotateproxy/db.db
 build
+*.ps1
+*.db

--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@
 ## 帮助
 
 ```shell
-> .\rotateproxy.exe -h
+.\rotateproxy.exe -h
 Usage of rotateproxy.exe:
+  -check string
+        check url (default "https://www.google.com")
+  -checkWords string
+        words in check url (default "Copyright The Closure Library Authors")
   -email string
         email address
   -l string
@@ -20,10 +24,14 @@ Usage of rotateproxy.exe:
         the page count you want to crawl (default 5)
   -pass string
         authentication password
+  -proxy string
+        proxy
   -region int
         0: all 1: cannot bypass gfw 2: bypass gfw
   -rule string
-        search rule (default "protocol==\"socks5\" && \"Version:5 Method:No Authentication(0x00)\" && after=\"2021-08-01\" && country=\"CN\"")
+        search rule (default "protocol==\"socks5\" && \"Version:5 Method:No Authentication(0x00)\" && after=\"2022-02-01\" && country=\"CN\"")
+  -strategy int
+        0: random, 1: Select the one with the shortest timeout, 2: Select the two with the shortest timeout, ... (default 3)
   -token string
         token
   -user string

--- a/check.go
+++ b/check.go
@@ -41,7 +41,7 @@ func CheckProxyAlive(proxyURL string) (respBody string, timeout int64, avail boo
 
 	// http://cip.cc isn't stable enough for proxies alive test.
 	resp, err := httpclient.Get("https://www.baidu.com/robots.txt")
-
+	
 	if err != nil {
 		return "", 0, false
 	}
@@ -52,7 +52,7 @@ func CheckProxyAlive(proxyURL string) (respBody string, timeout int64, avail boo
 		return "", 0, false
 	}
 	if !strings.Contains(string(body), "Baiduspider-image") {
-		return "", 0, false
+			return "", 0, false
 	}
 	return string(body), timeout, true
 }

--- a/check.go
+++ b/check.go
@@ -2,10 +2,6 @@ package rotateproxy
 
 import (
 	"crypto/tls"
-<<<<<<< HEAD
-=======
-	"fmt"
->>>>>>> 7e8cacba273ca6e9b5ed8167f8d9810248ff7b58
 	"io"
 	"net/http"
 	"net/url"
@@ -103,15 +99,9 @@ func StartCheckProxyAlive(checkURL string, checkURLwords string) {
 		for {
 			select {
 			case <-crawlDone:
-<<<<<<< HEAD
 				InfoLog(Noticeln("Checkings"))
 				checkAlive(checkURL, checkURLwords)
 				InfoLog(Noticeln("Check done"))
-=======
-				fmt.Println("Checking")
-				checkAlive(checkURL, checkURLwords)
-				fmt.Println("Check done")
->>>>>>> 7e8cacba273ca6e9b5ed8167f8d9810248ff7b58
 			case <-ticker.C:
 				checkAlive(checkURL, checkURLwords)
 			}

--- a/check.go
+++ b/check.go
@@ -3,7 +3,7 @@ package rotateproxy
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -38,23 +38,26 @@ func CheckProxyAlive(proxyURL string) (respBody string, timeout int64, avail boo
 		Timeout: 20 * time.Second,
 	}
 	startTime := time.Now()
-	resp, err := httpclient.Get("http://cip.cc/")
+
+	// http://cip.cc isn't stable enough for proxies alive test.
+	resp, err := httpclient.Get("https://www.baidu.com/robots.txt")
+
 	if err != nil {
 		return "", 0, false
 	}
 	defer resp.Body.Close()
 	timeout = int64(time.Since(startTime))
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", 0, false
 	}
-	if !strings.Contains(string(body), "地址") {
+	if !strings.Contains(string(body), "Baiduspider-image") {
 		return "", 0, false
 	}
 	return string(body), timeout, true
 }
 
-func CheckProxyWithCheckURL(proxyURL string, checkURL string) (timeout int64, avail bool) {
+func CheckProxyWithCheckURL(proxyURL string, checkURL string, checkURLwords string) (timeout int64, avail bool) {
 	fmt.Printf("check %s： %s\n", proxyURL, checkURL)
 	proxy, _ := url.Parse(proxyURL)
 	httpclient := &http.Client{
@@ -72,32 +75,41 @@ func CheckProxyWithCheckURL(proxyURL string, checkURL string) (timeout int64, av
 	}
 	defer resp.Body.Close()
 	timeout = int64(time.Since(startTime))
+	body, err := io.ReadAll(resp.Body)
+
+	if err != nil {
+		return 0, false
+	}
 
 	// TODO: support regex
 	if resp.StatusCode != 200 {
 		return 0, false
 	}
 
+	if !strings.Contains(string(body), checkURLwords) {
+		return 0, false
+	}
+
 	return timeout, true
 }
 
-func StartCheckProxyAlive(checkURL string) {
+func StartCheckProxyAlive(checkURL string, checkURLwords string) {
 	go func() {
 		ticker := time.NewTicker(120 * time.Second)
 		for {
 			select {
 			case <-crawlDone:
 				fmt.Println("Checking")
-				checkAlive(checkURL)
+				checkAlive(checkURL, checkURLwords)
 				fmt.Println("Check done")
 			case <-ticker.C:
-				checkAlive(checkURL)
+				checkAlive(checkURL, checkURLwords)
 			}
 		}
 	}()
 }
 
-func checkAlive(checkURL string) {
+func checkAlive(checkURL string, checkURLwords string) {
 	proxies, err := QueryProxyURL()
 	if err != nil {
 		fmt.Printf("[!] query db error: %v\n", err)
@@ -108,7 +120,7 @@ func checkAlive(checkURL string) {
 			respBody, timeout, avail := CheckProxyAlive(proxy.URL)
 			if avail {
 				if checkURL != "" {
-					timeout, avail = CheckProxyWithCheckURL(proxy.URL, checkURL)
+					timeout, avail = CheckProxyWithCheckURL(proxy.URL, checkURL, checkURLwords)
 				}
 				if avail {
 					fmt.Printf("%v 可用\n", proxy.URL)

--- a/cmd/rotateproxy/main.go
+++ b/cmd/rotateproxy/main.go
@@ -61,7 +61,9 @@ func main() {
 	}
 
 	// print fofa query
-	rotateproxy.InfoLog(rotateproxy.Notice("You fofa query for rotateproxy is : %v", rule))
+	rotateproxy.InfoLog(rotateproxy.Info("You fofa query for rotateproxy is : %v", rule))
+	rotateproxy.InfoLog(rotateproxy.Info("Check Proxy URL: %v", checkURL))
+	rotateproxy.InfoLog(rotateproxy.Info("Check Proxy Words: %v", checkURLwords))
 
 	baseCfg.ListenAddr = strings.TrimSpace(baseCfg.ListenAddr)
 

--- a/cmd/rotateproxy/main.go
+++ b/cmd/rotateproxy/main.go
@@ -60,6 +60,9 @@ func main() {
 		return
 	}
 
+	// print fofa query
+	rotateproxy.InfoLog(rotateproxy.Notice("You fofa query for rotateproxy is : %v", rule))
+
 	baseCfg.ListenAddr = strings.TrimSpace(baseCfg.ListenAddr)
 
 	if portPattern.Match([]byte(baseCfg.ListenAddr)) {

--- a/cmd/rotateproxy/main.go
+++ b/cmd/rotateproxy/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
@@ -9,14 +11,15 @@ import (
 )
 
 var (
-	baseCfg     rotateproxy.BaseConfig
-	email       string
-	token       string
-	rule        string
-	pageCount   int
-	proxy       string
-	checkURL    string
-	portPattern = regexp.MustCompile(`^\d+$`)
+	baseCfg       rotateproxy.BaseConfig
+	email         string
+	token         string
+	rule          string
+	pageCount     int
+	proxy         string
+	checkURL      string
+	checkURLwords string
+	portPattern   = regexp.MustCompile(`^\d+$`)
 )
 
 func init() {
@@ -28,10 +31,17 @@ func init() {
 	flag.StringVar(&proxy, "proxy", "", "proxy")
 	flag.StringVar(&rule, "rule", `protocol=="socks5" && "Version:5 Method:No Authentication(0x00)" && after="2022-02-01" && country="CN"`, "search rule")
 	flag.StringVar(&checkURL, "check", `https://www.google.com`, "check url")
+	flag.StringVar(&checkURLwords, "checkWords", `Copyright The Closure Library Authors`, "words in check url")
 	flag.IntVar(&baseCfg.IPRegionFlag, "region", 0, "0: all 1: cannot bypass gfw 2: bypass gfw")
 	flag.IntVar(&baseCfg.SelectStrategy, "strategy", 3, "0: random, 1: Select the one with the shortest timeout, 2: Select the two with the shortest timeout, ...")
 	flag.IntVar(&pageCount, "page", 5, "the page count you want to crawl")
 	flag.Parse()
+
+	if checkURL != "https://www.google.com" && checkURLwords == "Copyright The Closure Library Authors" {
+		fmt.Println("You set check url but forget to set `-checkWords`!")
+		os.Exit(1)
+	}
+
 }
 
 func isFlagPassed(name string) bool {
@@ -57,7 +67,7 @@ func main() {
 	}
 
 	rotateproxy.StartRunCrawler(token, email, rule, pageCount, proxy)
-	rotateproxy.StartCheckProxyAlive(checkURL)
+	rotateproxy.StartCheckProxyAlive(checkURL, checkURLwords)
 	c := rotateproxy.NewRedirectClient(rotateproxy.WithConfig(&baseCfg))
 	c.Serve()
 	select {}

--- a/crawler.go
+++ b/crawler.go
@@ -53,14 +53,14 @@ func RunCrawler(fofaApiKey, fofaEmail, rule string, pageNum int, proxy string) (
 	if err != nil {
 		return err
 	}
-	fmt.Printf("start to parse proxy url from response\n")
+	InfoLog(Noticeln("start to parse proxy url from response"))
 	defer resp.Body.Close()
 	var res fofaAPIResponse
 	err = json.NewDecoder(resp.Body).Decode(&res)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("get %d host\n", len(res.Results))
+	InfoLog(Notice("get %d host", len(res.Results)))
 	for _, value := range res.Results {
 		host := value[0]
 		addProxyURL(fmt.Sprintf("socks5://%s", host))
@@ -74,7 +74,7 @@ func StartRunCrawler(fofaApiKey, fofaEmail, rule string, pageCount int, proxy st
 		for i := 1; i <= 3; i++ {
 			err := RunCrawler(fofaApiKey, fofaEmail, rule, i, proxy)
 			if err != nil {
-				fmt.Printf("[!] error: %v\n", err)
+				ErrorLog(Warn("[!] error: %v", err))
 			}
 		}
 	}

--- a/db.go
+++ b/db.go
@@ -86,6 +86,7 @@ func SetProxyURLAvail(url string, timeout int64, canBypassGFW bool) error {
 
 func SetProxyURLUnavail(url string) error {
 	tx := DB.Model(&ProxyURL{}).Where("url = ?", url).Updates(ProxyURL{Retry: 0, Available: false})
+	ErrorLog(Notice("Mark %v Unavailble! ", url))
 	return tx.Error
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,13 +10,15 @@ require (
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/fatih/color v1.16.0
 	github.com/glebarez/go-sqlite v1.20.3 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-isatty v0.0.17 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230126093431-47fa9a501578 // indirect
-	golang.org/x/sys v0.4.0 // indirect
+	golang.org/x/sys v0.14.0 // indirect
 	modernc.org/libc v1.22.2 // indirect
 	modernc.org/mathutil v1.5.0 // indirect
 	modernc.org/memory v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/chzyer/test v0.0.0-20210722231415-061457976a23/go.mod h1:Q3SI9o4m/ZMn
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
+github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/glebarez/go-sqlite v1.20.3 h1:89BkqGOXR9oRmG58ZrzgoY/Fhy5x0M+/WV48U5zVrZ4=
 github.com/glebarez/go-sqlite v1.20.3/go.mod h1:u3N6D/wftiAzIOJtZl6BmedqxmmkDfH3q+ihjqxC9u0=
 github.com/glebarez/sqlite v1.7.0 h1:A7Xj/KN2Lvie4Z4rrgQHY8MsbebX3NyWsL3n2i82MVI=
@@ -21,9 +23,12 @@ github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.15/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
@@ -46,8 +51,10 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/traffic_redirect.go
+++ b/traffic_redirect.go
@@ -18,15 +18,15 @@ const (
 )
 
 var (
-	largeBufferSize = 32 * 1024 // 32KB large buffer
+	largeBufferSize   = 32 * 1024 // 32KB large buffer
 	ErrNotSocks5Proxy = errors.New("this is not a socks proxy server")
 )
 
 type BaseConfig struct {
-	ListenAddr   string
-	IPRegionFlag int // 0: all 1: cannot bypass gfw 2: bypass gfw
-	Username string
-	Password string
+	ListenAddr     string
+	IPRegionFlag   int // 0: all 1: cannot bypass gfw 2: bypass gfw
+	Username       string
+	Password       string
 	SelectStrategy int // 0: random, 1: Select the one with the shortest timeout, 2: Select the two with the shortest timeout, ...
 }
 
@@ -45,7 +45,6 @@ type AuthPreProcessor struct {
 type NoAuthPreProcessor struct {
 	cfg BaseConfig
 }
-
 
 // DownstreamPreProcess auth for socks5 server(local)
 func (p *AuthPreProcessor) DownstreamPreProcess(conn net.Conn) (err error) {
@@ -108,7 +107,7 @@ func (p *AuthPreProcessor) UpstreamPreProcess(conn net.Conn) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err = fmt.Errorf("%v", e)
-			fmt.Printf("close connection: %v\n", err)
+			ErrorLog(Warn("close connection: %v", err))
 		}
 	}()
 	if conn == nil {
@@ -145,7 +144,6 @@ func NewNoAuthPreProcessor(cfg BaseConfig) *NoAuthPreProcessor {
 	return &NoAuthPreProcessor{cfg: cfg}
 }
 
-
 type RedirectClient struct {
 	config *BaseConfig
 
@@ -181,13 +179,13 @@ func (c *RedirectClient) Serve() error {
 		return err
 	}
 	for IsProxyURLBlank() {
-		fmt.Println("[*] waiting for crawl proxy...")
+		InfoLog(Noticeln("[*] waiting for crawl proxy..."))
 		time.Sleep(3 * time.Second)
 	}
 	for {
 		conn, err := l.Accept()
 		if err != nil {
-			fmt.Printf("[!] accept error: %v\n", err)
+			ErrorLog(Warn("[!] accept error: %v", err))
 			continue
 		}
 		go c.HandleConn(conn)
@@ -206,9 +204,10 @@ func (c *RedirectClient) getValidSocks5Connection() (net.Conn, error) {
 		cc, err = net.DialTimeout("tcp", key, 5*time.Second)
 		if err != nil {
 			closeConn(cc)
-			fmt.Printf("[!] cannot connect to %v\n", key)
+			markUnavail()
+			ErrorLog(Warn("[!] cannot connect to %v", key))
 		}
-		fmt.Printf("[*] use %v\n", key)
+		InfoLog(Info("[*] use %v", key))
 		// write header for remote socks5 server
 		err = c.preProcessor.UpstreamPreProcess(cc)
 		if err != nil {
@@ -216,10 +215,10 @@ func (c *RedirectClient) getValidSocks5Connection() (net.Conn, error) {
 			if errors.Is(err, ErrNotSocks5Proxy) {
 				// 将该代理设置为不可用
 				markUnavail()
-				fmt.Println(err)
+				ErrorLog(Warn("Error : %v", err))
 				continue
 			}
-			fmt.Printf("socks handshake with downstream failed: %v\n", err)
+			ErrorLog(Warn("socks handshake with downstream failed: %v", err))
 			continue
 		}
 		break
@@ -232,18 +231,18 @@ func (c *RedirectClient) HandleConn(conn net.Conn) {
 	// auth for local socks5 serer
 	err := c.preProcessor.DownstreamPreProcess(conn)
 	if err != nil {
-		fmt.Printf("[!] socks handshake with downstream failed: %v\n", err)
+		ErrorLog(Warn("[!] socks handshake with downstream failed: %v", err))
 		return
 	}
 	cc, err := c.getValidSocks5Connection()
 	if err != nil {
-		fmt.Printf("[!] getValidSocks5Connection failed: %v\n", err)
+		ErrorLog(Warn("[!] getValidSocks5Connection failed: %v", err))
 		return
 	}
 	defer closeConn(cc)
 	err = transport(conn, cc)
 	if err != nil {
-		fmt.Printf("[!] transport error: %v\n", err)
+		ErrorLog(Warn("[!] transport error: %v", err))
 	}
 }
 
@@ -251,7 +250,7 @@ func closeConn(conn net.Conn) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err = fmt.Errorf("%v", e)
-			fmt.Printf("[*] close connection: %v\n", err)
+			ErrorLog(Warn("[*] close connection: %v", err))
 		}
 	}()
 	err = conn.Close()
@@ -260,11 +259,11 @@ func closeConn(conn net.Conn) (err error) {
 
 func transport(rw1, rw2 io.ReadWriter) error {
 	g, _ := errgroup.WithContext(context.Background())
-	g.Go(func() error{
+	g.Go(func() error {
 		return copyBuffer(rw1, rw2)
 	})
 
-	g.Go(func() error{
+	g.Go(func() error {
 		return copyBuffer(rw2, rw1)
 	})
 	var err error

--- a/util.go
+++ b/util.go
@@ -2,11 +2,14 @@ package rotateproxy
 
 import (
 	"errors"
-	"fmt"
 	"io"
+	"log"
 	"math/rand"
+	"os"
 	"sync"
 	"time"
+
+	"github.com/fatih/color"
 )
 
 var errInvalidWrite = errors.New("invalid write result")
@@ -30,7 +33,7 @@ func RandomSyncMap(sMap sync.Map) (key, value interface{}) {
 func IsProxyURLBlank() bool {
 	proxies, err := QueryAvailProxyURL()
 	if err != nil {
-		fmt.Printf("[!] Error: %v\n", err)
+		ErrorLog(Warn("[!] Error: %v", err))
 		return false
 	}
 	return len(proxies) == 0
@@ -93,3 +96,15 @@ func CopyBufferWithCloseErr(dst io.Writer, src io.Reader, buf []byte) (written i
 	}
 	return written, err
 }
+
+var (
+	Notice   = color.New(color.FgBlue).SprintfFunc()
+	Noticeln = color.New(color.FgBlue).SprintFunc()
+	Info     = color.New(color.FgGreen).SprintfFunc()
+	Warn     = color.New(color.FgRed).SprintfFunc()
+)
+
+var (
+	InfoLog  = log.New(os.Stdout, "", log.Ldate|log.Ltime|log.Lshortfile).Println
+	ErrorLog = log.New(os.Stdout, "", log.Ldate|log.Ltime|log.Lshortfile).Println
+)


### PR DESCRIPTION
The PR support content check while testing proxy URL in func `CheckProxyWithCheckURL` at `check.go`. Enable by command line parameter `-checkWords`.
```
func CheckProxyWithCheckURL(proxyURL string, checkURL string) (timeout int64, avail bool) {
func CheckProxyWithCheckURL(proxyURL string, checkURL string, checkURLwords string) (timeout int64, avail bool) {
```

It also changes proxy alive check URL from http://cip.cc to https://www.baidu.com/robots.txt in func `CheckProxyWithCheckURL` for better reliability.

```
	resp, err := httpclient.Get("http://cip.cc/")

	// http://cip.cc isn't stable enough for proxies alive test.
	resp, err := httpclient.Get("https://www.baidu.com/robots.txt")
```